### PR TITLE
Remove the coe from `id A` to `A`

### DIFF
--- a/YatimaStdLib/Identity.lean
+++ b/YatimaStdLib/Identity.lean
@@ -3,10 +3,7 @@ namespace Identity
 structure Identity (A : Type α) where
   runIdentity : A
 
-@[inline] instance idToA : Coe (Identity A) A where
-  coe a := a.runIdentity
-
-@[inline] instance aToIdA : Coe A (Identity A) where
+instance : Coe A (Identity A) where
   coe a := Identity.mk a
 
 end Identity


### PR DESCRIPTION
# Why 

If we have 
```lean
@[inline] instance idToA : Coe (Identity A) A where
  coe a := a.runIdentity
```
then `#check ((1 : Nat) : Option Nat)` doesn't work. This is probably due to typeclass resolution being stuck in a `A -> Id A -> A ...` cycle. 

# How 
Removing the instance fixes this issue. I think it is worth it as breaking all of the implicit `a -> some a` coercions is disruptive (for example the `Cli` lib relies on it). 