### PR TITLE
Bumps toolchain to nightly-2022-08-09 

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-31
+leanprover/lean4:nightly-2022-08-09


### PR DESCRIPTION
## Why

We want to generate and host our documentation using `doc-gen4` which requires a toolchain bump compatible with the latest DocGen4 commits.