### PR TITLE
Extend NEList and move utilities from Megaparsec

### DIFF
--- a/YatimaStdLib.lean
+++ b/YatimaStdLib.lean
@@ -12,6 +12,7 @@ import YatimaStdLib.Option
 import YatimaStdLib.RBMap
 import YatimaStdLib.RBNode
 import YatimaStdLib.RWST
+import YatimaStdLib.Seq
 import YatimaStdLib.String
 import YatimaStdLib.Traversable
 import YatimaStdLib.Tree

--- a/YatimaStdLib/NonEmpty.lean
+++ b/YatimaStdLib/NonEmpty.lean
@@ -8,17 +8,28 @@
 This file contains definitions for `NEList`, an inductive type meant to
 represent non-empty lists.
 -/
+import YatimaStdLib.Applicative
 import YatimaStdLib.Foldable
+import YatimaStdLib.Traversable
 
-inductive NEList (A : Type _)
-  | uno  : A → NEList A
-  | cons : A → NEList A → NEList A
--- TODO: introduce notation
+inductive NEList (α : Type _)
+  | uno  : α → NEList α
+  | cons : α → NEList α → NEList α
+
+-- TODO: add macros for full NEList shortcut syntax, similar to `[a, b, c]`
+infixr:67 " :| " => NEList.cons
+notation:max "⟦" x "⟧" => NEList.uno x
+
+instance [ToString α] : ToString (NEList α) where
+  toString
+    | ⟦x⟧ => s!"⟦{x}⟧"
+    | xs => let rec go | ⟦e⟧ => s!"{e}" | e :| es => s!"{e}, {go es}"
+      s!"⟦{go xs}⟧"
 
 namespace NEList
 
-/-- Creates a term of `List A` from the elements of a term of `NEList A` -/
-def toList : NEList A → List A
+/-- Creates a term of `List α` from the elements of a term of `NEList α` -/
+def toList : NEList α → List α
   | .uno  a   => [a]
   | .cons a b => a :: toList b
 
@@ -26,7 +37,7 @@ def toList : NEList A → List A
 The `specialize` tag forces the compiler to create a version of the function
 for each `f` used for optimization purposes -/
 @[specialize]
-def foldl (f : B → A → B) (init : B) (l : NEList A) : B :=
+def foldl (f : β → α → β) (init : β) (l : NEList α) : β :=
   match l with
     | .uno x => f init x
     | .cons x xs => foldl f (f init x) xs
@@ -35,7 +46,7 @@ def foldl (f : B → A → B) (init : B) (l : NEList A) : B :=
 The `specialize` tag forces the compiler to create a version of the function
 for each `f` used for optimization purposes -/
 @[specialize]
-def foldr (f : A → B → B) (init : B) (l : NEList A) : B :=
+def foldr (f : α → β → β) (init : β) (l : NEList α) : β :=
   match l with
     | .uno x => f x init
     | .cons x xs => foldr f (f x init) xs
@@ -51,7 +62,7 @@ def map (f : α → β) : NEList α → NEList β
 instance : Functor NEList where
   map := NEList.map
 
-instance BEqOfOrd [Ord T] : BEq T where
+instance BEqOfOrd [Ord τ] : BEq τ where
   beq x y := compare x y == Ordering.eq
 
 protected def beq [BEq α] : NEList α → NEList α → Bool
@@ -59,11 +70,12 @@ protected def beq [BEq α] : NEList α → NEList α → Bool
   | .cons a as, .cons b bs => a == b && NEList.beq as bs
   | _,          _          => false
 
-instance [BEq T] : BEq $ NEList T := ⟨NEList.beq⟩
+instance [BEq τ] : BEq $ NEList τ := ⟨NEList.beq⟩
 
-def nonEmpty (l : List A) : Option (NEList A) :=
+def nonEmpty (l : List α) : Option (NEList α) :=
   match l with
   | [] => Option.none
+  | [x] => Option.some $ NEList.uno x
   | (x :: xs) => NEList.cons x <$> nonEmpty xs
 
 def nonEmptyString (s : String) : Option (NEList Char) :=
@@ -80,12 +92,23 @@ instance : Foldable NEList where
   foldr := NEList.foldr
   foldl := NEList.foldl
 
+def traverse [Applicative φ] (f : α → φ β) : NEList α → φ (NEList β)
+  | ⟦x⟧ => .uno <$> f x
+  | x :| xs => Applicative.liftA₂ (.cons) (f x) $ traverse f xs
+
+open Traversable in
+instance : Traversable NEList where
+  traverse := NEList.traverse
+
+instance : Pure NEList where
+  pure x := ⟦x⟧
+
 end NEList
 
 namespace List
 
-/-- Builds an `NEList A` from a term of `A` and a term of `List A` -/
-def toNEList (a : A) : List A → NEList A
+/-- Builds an `NEList α` from a term of `α` and a term of `List α` -/
+def toNEList (a : α) : List α → NEList α
   | []      => .uno a
   | b :: bs => .cons a (toNEList b bs)
 

--- a/YatimaStdLib/RWST.lean
+++ b/YatimaStdLib/RWST.lean
@@ -3,12 +3,12 @@ import YatimaStdLib.Algebra.Defs
 def RWST (R W S : Type u) (M : Type u → Type v) (A : Type u) : Type (max u v) :=
   R → S → M (A × S × W)
 
+def void [Functor φ] (fx : φ a) : φ Unit :=
+  (fun _ => ()) <$> fx
+
 namespace RWST
 
 /-- RWS monad and its transformer and required utilities -/
-
-def void [Monad M] (ma : M A) : M Unit :=
-  (fun _ => ()) <$> ma
 
 instance mrwsₜ (R W S : Type) [Monoid W] [Monad M] : Monad (RWST R W S M) where
   map f x := fun r s => do {

--- a/YatimaStdLib/Seq.lean
+++ b/YatimaStdLib/Seq.lean
@@ -1,0 +1,9 @@
+namespace Seq
+
+def between [SeqLeft φ] [SeqRight φ] (f : φ α) (h : φ β) (g : φ γ) : φ γ :=
+  f *> g <* h
+
+def liftSeq₂ [Seq φ] [Functor φ] (f2 : α → β → γ) (x : φ α)
+  : (Unit → φ β) → φ γ := Seq.seq $ f2 <$> x
+
+end Seq

--- a/YatimaStdLib/Traversable.lean
+++ b/YatimaStdLib/Traversable.lean
@@ -1,7 +1,6 @@
 import YatimaStdLib.Applicative
 import YatimaStdLib.Foldable
 import YatimaStdLib.List
-import YatimaStdLib.NonEmpty
 
 namespace Traversable
 
@@ -25,9 +24,6 @@ def mapM [Monad M] [Functor T] [Foldable T] [Traversable T] : (A → M B) → T 
 
 def sequence [Monad M] [Functor T] [Foldable T] [Traversable T] : T (M A) → M (T A) :=
   sequenceA
-
-instance funList : Functor List where
-  map := List.map
 
 instance trList : Traversable List where
   traverse f :=


### PR DESCRIPTION
Problem: `NEList.nonEmpty` has a bug: it will never produce a `.some`. We need this fixed for Megaparsec.
Additionally, there's some stuff defined in Megaparsec that would be more useful in YatimaStdLib, and we want to move it here.

Solution: fixed the bug. Added functions `void`, `between`, and `liftSeq2` to reasonable locations in YatimaStdLib. Also, `NEList` was lacking some useful instances, e.g. of `ToString`, so they were added along with `Traversable` and `Pure` instances. 