### PR TITLE
HashSet and HashMap methods

### DIFF
--- a/YatimaStdLib/HashMap.lean
+++ b/YatimaStdLib/HashMap.lean
@@ -1,0 +1,10 @@
+import Lean.Data.HashMap
+import YatimaStdLib.HashSet
+
+namespace Std
+
+def HashMap.unionWith {α β : Type _} [BEq α] [Hashable α] [Inhabited β] (combine : β → β → β) 
+    (s₁ s₂ : HashMap α β) : HashMap α β := 
+  s₁.fold 
+    (fun map key value => 
+      map.insert key (combine value <| map.findD key default)) s₂

--- a/YatimaStdLib/HashSet.lean
+++ b/YatimaStdLib/HashSet.lean
@@ -1,0 +1,25 @@
+import Lean.Data.HashSet
+
+syntax "⦃" term,* "⦄" : term
+
+open Std
+
+open Lean in
+macro_rules
+  | `(⦃$xs,*⦄) => do
+    let mut acc : TSyntax `term ← `(HashSet.empty)
+    for x in xs.getElems do
+      acc ← `(HashSet.insert $acc $x)
+    return ← `($acc)
+
+instance [ToString α] [BEq α] [Hashable α] : ToString (HashSet α) where
+  toString set := 
+    let content := ", ".intercalate (set |>.toList |>.reverse |>.map fun k => s!"{k}")
+    s!"⦃{content}⦄"
+
+namespace Std.HashSet
+
+def union {α : Type _} [BEq α] [Hashable α] (s t : HashSet α) : HashSet α :=
+  s.fold (HashSet.insert) t
+
+infix:50 "∪" => union


### PR DESCRIPTION
This PR adds the `HashSet.union` method, and the `HashMap.unionWith` methods.

It also adds notation for `HashSet` so we can get nice stuff like

```lean
#eval ⦃1,2,3⦄ ∪ ⦃5, 4, 3⦄ -- ⦃1, 2, 3, 4, 5⦄
```

## Notes

* I know we don't generally use `HashSet` or `HashMap` in our repos, but the main usecase here is for the `Graph.lean` project.

* I'm not sure if there's a better way of implementing the HashSet notation, so I'm open to suggestions. 