### PR TITLE
Add Cached data type

### DIFF
--- a/YatimaStdLib.lean
+++ b/YatimaStdLib.lean
@@ -2,6 +2,7 @@ import YatimaStdLib.AbstractMatrix
 import YatimaStdLib.Algebra.Defs
 import YatimaStdLib.Applicative
 import YatimaStdLib.ByteArray
+import YatimaStdLib.Cached
 import YatimaStdLib.Either
 import YatimaStdLib.Foldable
 import YatimaStdLib.Identity

--- a/YatimaStdLib/Cached.lean
+++ b/YatimaStdLib/Cached.lean
@@ -1,0 +1,18 @@
+namespace Cached
+
+structure Cached {α : Type u} {β : Type v} (f : α → β) (x : α) :=
+  val : β
+  isFX : f x = val
+  deriving Repr
+
+instance : EmptyCollection (Cached f x) where emptyCollection := ⟨f x, rfl⟩
+instance : Inhabited (Cached f x) where default := {}
+instance : Subsingleton (Cached f x) where
+  allEq := fun ⟨b, hb⟩ ⟨c, hc⟩ => by subst hb; subst hc; rfl
+instance : DecidableEq (Cached f x) := fun _ _ => isTrue (Subsingleton.allEq ..)
+instance [ToString β] : ToString (@Cached α β f x) where
+  toString c := toString c.val
+
+abbrev Cached' (a : α) := Cached id a
+
+end Cached


### PR DESCRIPTION
Problem: there is no easy construct in Lean/YatimaStdLib that allows to memoize and/or force just one value to be considered valid on the type level.

Solution: added `Cached` data type, which allows to memoize a function application and the resulting value. We also defined a `Cached'` utility abbreviation that uses `id` to allow for just the value memoization.