### PR TITLE
Remove Zmod notation

### DIFF
--- a/YatimaStdLib/Zmod.lean
+++ b/YatimaStdLib/Zmod.lean
@@ -13,12 +13,8 @@ def rep (a : Zmod n) : Int := a
 instance : Add (Zmod n) where
   add (a b : Zmod n) := (rep a + rep b) % (n : Int)
 
-notation:50 a "  + " b " mod " n => Add.add (a : Zmod n) (b : Zmod n)
-
 instance : Mul (Zmod n) where
   mul (a b : Zmod n) := (rep a * rep b) % (n : Int)
-
-notation:51 a " * " b " mod " n => Mul.mul (a : Zmod n) (b : Zmod n)
 
 instance : Inhabited (Zmod n) where
   default := 0
@@ -36,8 +32,6 @@ instance : Pow (Zmod n) Nat where
 
 instance : Sub (Zmod n) where
   sub (a b : Zmod n) := (rep a - rep b) % (n : Int)
-
-notation:50 a " - " b " mod " n => Sub.sub (a : Zmod n) (b : Zmod n)
 
 def modInv (a : Zmod n) : Zmod n := Int.modInv a n
 


### PR DESCRIPTION
# Problem:

The notation introduced in the Zmod file was conflicting with the usual arithmetic operations `+`, `*`, and `-` for the natural numbers.

# Solution:

Just get rid of it for now. 