### PR TITLE
Add Subsingleton equality theorem for simp

### DIFF
--- a/YatimaStdLib/Cached.lean
+++ b/YatimaStdLib/Cached.lean
@@ -13,6 +13,10 @@ instance : DecidableEq (Cached f x) := fun _ _ => isTrue (Subsingleton.allEq ..)
 instance [ToString β] : ToString (@Cached α β f x) where
   toString c := toString c.val
 
+@[simp]
+theorem eq_of_subsingleton [Subsingleton α] {a b : α} : (a = b) = True := by
+  simp [Subsingleton.allEq a b]
+
 abbrev Cached' (a : α) := Cached id a
 
 end Cached


### PR DESCRIPTION
Problem: `Cached` ultimately represents a singleton value, and so two values of `Cached` of the same type must be equal to each other. It'd be nice for the simplifier to be able to use that. We've had a small theorem but forgot to put it in.

Solution: added the `@[simp]` theorem back.