### PR TITLE
Fix namespaces

### DIFF
--- a/YatimaStdLib/Bit.lean
+++ b/YatimaStdLib/Bit.lean
@@ -43,13 +43,13 @@ end bit_methods
 
 namespace Bit
 
-def bitArXOr (bs : Array Bit) : Bit :=
+def arrayXOr (bs : Array Bit) : Bit :=
   bs.foldl (fun b b' => b.xOr b') zero
 
-def bitArToNat (bs : Array Bit) : Nat :=
+def arrayToNat (bs : Array Bit) : Nat :=
   bs.foldl (fun b b' => b * 2 + b'.toNat) 0
 
-def pad (n : Nat) (bs : List Bit) : List Bit :=
+def listPad (n : Nat) (bs : List Bit) : List Bit :=
   let l := bs.length
   if l >= n then bs else List.replicate (n - l) zero ++ bs
 
@@ -77,7 +77,7 @@ def Nat.toBits : Nat → List Bit
   decreasing_by exact Nat.div2_lt h₁;
 
 def UInt8.toBits (u : UInt8) : List Bit :=
-  Bit.pad 8 $ Nat.toBits $ UInt8.toNat u
+  Bit.listPad 8 $ Nat.toBits $ UInt8.toNat u
 
 def ByteArray.toBits (ba : ByteArray) : List Bit :=
   List.join $ List.map UInt8.toBits $ ByteArray.toList ba

--- a/YatimaStdLib/Bit.lean
+++ b/YatimaStdLib/Bit.lean
@@ -1,0 +1,83 @@
+import YatimaStdLib.Nat
+
+inductive Endian where
+  | big    : Endian
+  | little : Endian
+  deriving Repr, DecidableEq, Inhabited
+
+inductive Bit where
+  | zero
+  | one
+  deriving DecidableEq, Inhabited
+
+instance : ToString Bit where
+  toString
+    | .one  => "1"
+    | .zero => "0"
+
+instance : OfNat Bit 0 where
+  ofNat := .zero
+
+instance : OfNat Bit 1 where
+  ofNat := .one
+
+section bit_methods
+
+namespace Bit
+
+def xOr : Bit → Bit → Bit
+  | one, zero
+  | zero, one => one
+  | _, _      => zero
+
+def toNat : Bit → Nat
+  | zero => 0
+  | one  => 1
+
+def toUInt8 : Bit → UInt8 :=
+  Nat.toUInt8 ∘ Bit.toNat
+
+end Bit
+
+end bit_methods
+
+namespace Bit
+
+def bitArXOr (bs : Array Bit) : Bit :=
+  bs.foldl (fun b b' => b.xOr b') zero
+
+def bitArToNat (bs : Array Bit) : Nat :=
+  bs.foldl (fun b b' => b * 2 + b'.toNat) 0
+
+def pad (n : Nat) (bs : List Bit) : List Bit :=
+  let l := bs.length
+  if l >= n then bs else List.replicate (n - l) zero ++ bs
+
+-- Interprets a `List Bit` as a `Nat`, taking `Endian`ness into consideration.
+def bitsToNat (l: List Bit) (en : Endian := default) : Nat :=
+  let rec go
+    | [], acc => acc
+    | b :: bs, acc => go bs $ acc * 2 + (if b = zero then 0 else 1)
+  let bits := if en = .big then l else List.reverse l
+  go bits default
+
+-- Takes first `n` elems of the `List Bit` and interprets them as a `Nat`.
+-- Returns `none` if the list is shorter than `n`.
+def someBitsToNat? (n : Nat) (l: List Bit) (en : Endian := default) : Option Nat :=
+  if n > l.length || n = 0 then .none else .some $ bitsToNat (l.take n) en
+
+end Bit
+
+def Nat.toBits : Nat → List Bit
+  | 0 => [.zero]
+  | 1 => [.one]
+  | n + 2 =>
+    have h₁ : n + 2 ≠ 0 := by simp_arith
+    Nat.toBits ((n + 2) / 2) ++ (if n % 2 = 0 then [.zero] else [.one])
+  decreasing_by exact Nat.div2_lt h₁;
+
+def UInt8.toBits (u : UInt8) : List Bit :=
+  Bit.pad 8 $ Nat.toBits $ UInt8.toNat u
+
+def ByteArray.toBits (ba : ByteArray) : List Bit :=
+  List.join $ List.map UInt8.toBits $ ByteArray.toList ba

--- a/YatimaStdLib/Float.lean
+++ b/YatimaStdLib/Float.lean
@@ -2,7 +2,7 @@ namespace Float
 
 open Float (log)
 
-def Float.toNat : Float → Nat := USize.toNat ∘ Float.toUSize
+def toNat : Float → Nat := USize.toNat ∘ Float.toUSize
 
 def logBase (base arg : Float) : Float := log arg / log base
 

--- a/YatimaStdLib/Nat.lean
+++ b/YatimaStdLib/Nat.lean
@@ -80,3 +80,14 @@ def gcdB (x y : Nat) : Int := (xgcd x y).2
 end GCD
 
 end Nat
+
+theorem Nat.div2_lt (h : n ≠ 0) : n / 2 < n := by
+  match n with
+  | 1   => decide
+  | 2   => decide
+  | 3   => decide
+  | n+4 =>
+    rw [Nat.div_eq, if_pos]
+    refine Nat.succ_lt_succ (Nat.lt_trans ?_ (Nat.lt_succ_self _))
+    exact @div2_lt (n + 2) (by simp_arith)
+    simp_arith

--- a/YatimaStdLib/NonEmpty.lean
+++ b/YatimaStdLib/NonEmpty.lean
@@ -121,6 +121,8 @@ def toNEList (a : α) : List α → NEList α
   | []      => .uno a
   | b :: bs => .cons a (toNEList b bs)
 
+end List
+
 def NEList.min {α : Type _ } [LE α] [DecidableRel (@LE.le α _)] : NEList α → α
   | .uno a     => a
   | .cons a as => if a ≤ (min as) then a else (min as)
@@ -128,5 +130,4 @@ def NEList.min {α : Type _ } [LE α] [DecidableRel (@LE.le α _)] : NEList α �
 def NEList.max {α : Type _ } [LE α] [DecidableRel (@LE.le α _)] : NEList α → α
   | .uno a     => a
   | .cons a as => if a ≤ (max as) then (max as) else a
-
-end List
+  

--- a/YatimaStdLib/UInt.lean
+++ b/YatimaStdLib/UInt.lean
@@ -1,0 +1,8 @@
+import YatimaStdLib.Bit
+
+def UInt8.showBits (u : UInt8) : String :=
+  let numStr := u.toNat |> Nat.toDigits 2
+  "".pushn '0' (8 - numStr.length) ++ ⟨numStr⟩
+
+def UInt8.getBit (u : UInt8) (n : Nat) : Bit :=
+  if u &&& (1 <<< (7 - n)).toUInt8 == 0 then .zero else .one


### PR DESCRIPTION
A recent merged PR added a few methods from the `Poseidon.lean` repository, but did not preserve the namespaces. This PR fixes the namespace issue, and re-organizes slightly the dependencies between `Bit`, `ByteArray`, and `UInt`