### PR TITLE
Add some RBMap utilities

### DIFF
--- a/YatimaStdLib/RBMap.lean
+++ b/YatimaStdLib/RBMap.lean
@@ -18,11 +18,11 @@ def filterOut [BEq α] [Ord α] (map : RBMap α β cmp) (t : RBTree α cmp) :
   map.fold (init := default) fun acc a b =>
     if t.contains a then acc else acc.insert a b
 
-def toKeyList : RBMap α β cmp → List α
-  | ⟨t, _⟩ => t.revFold (fun ks k _ => k::ks) []
+def keys : RBMap α β cmp → Array α
+  | ⟨t, _⟩ => t.revFold (fun ks k _ => ks.push k) .empty
 
-def toValueList : RBMap α β cmp → List β
-  | ⟨t, _⟩ => t.revFold (fun vs _ v => v::vs) []
+def values : RBMap α β cmp → Array β
+  | ⟨t, _⟩ => t.revFold (fun vs _ v => vs.push v) .empty
 
 /-
   Merge two RBMaps, always taking the first value in case of a key

--- a/YatimaStdLib/RBMap.lean
+++ b/YatimaStdLib/RBMap.lean
@@ -2,20 +2,35 @@ import Lean
 
 namespace Std.RBMap
 
-variable {cmp : α → α → Ordering} 
+variable {cmp : α → α → Ordering}
 
-instance : Inhabited (RBMap α β cmp) where
-  default := .empty
-
-def single (a : α) (b : β) : RBMap α β cmp := 
+def single (a : α) (b : β) : RBMap α β cmp :=
   RBMap.empty.insert a b
 
-def enumList (xs : List α) : RBMap α Nat cmp := 
+def enumList (xs : List α) : RBMap α Nat cmp :=
   RBMap.ofList $ xs.enum.map (fun (x, y) => (y, x))
+
+def unitMap (xs : List α) : RBMap α Unit cmp :=
+  RBMap.ofList $ xs.map (fun x => (x, ()))
 
 def filterOut [BEq α] [Ord α] (map : RBMap α β cmp) (t : RBTree α cmp) :
     RBMap α β cmp :=
   map.fold (init := default) fun acc a b =>
     if t.contains a then acc else acc.insert a b
+
+def toKeyList : RBMap α β cmp → List α
+  | ⟨t, _⟩ => t.revFold (fun ks k _ => k::ks) []
+
+def toValueList : RBMap α β cmp → List β
+  | ⟨t, _⟩ => t.revFold (fun vs _ v => v::vs) []
+
+/-
+  Merge two RBMaps, always taking the first value in case of a key
+  being present in both maps. Intended for set simulation.
+-/
+def mergeKeySets (m1 : RBMap α β cmp) m2 :=
+  RBMap.mergeBy (fun _ v _ => v) m1 m2
+
+instance : Append (RBMap α Unit cmp) := ⟨RBMap.mergeKeySets⟩
 
 end Std.RBMap


### PR DESCRIPTION
Problem: we need to use RBMap in Megaparsec, simulating finite computable sets through RBMap with Unit as nominal values. For ease of use, we need a way to construct such a map from just a list of keys, i.e. real values, as well as extract keys and merge and append two such "sets".

Solution: added these functions to RBMap module. Also deleted the Inhabited instance for RBMap as the same definition is present in Lean's stdlib.