### PR TITLE
Bump toolchain to 2022-10-27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.olean
 result*
 /build
-/lean_packages
+/lean_packages/*
+!/lean_packages/manifest.json

--- a/YatimaStdLib/AbstractMatrix.lean
+++ b/YatimaStdLib/AbstractMatrix.lean
@@ -1,5 +1,5 @@
 /-
-This is oen attempt at writing down the implementation of a Matrix/Vector library for Poseidon.
+This is one attempt at writing down the implementation of a Matrix/Vector library for Poseidon.
 I'm fairly certain this would be unwieldy to use in practice, so we prefer the implementation in
 `Matrix.lean`.
 WARNING: There's like a 50% chance I got the transposes wrong in these definitions, so the first

--- a/YatimaStdLib/HashMap.lean
+++ b/YatimaStdLib/HashMap.lean
@@ -1,4 +1,4 @@
-import Lean.Data.HashMap
+import Std.Data.HashMap
 import YatimaStdLib.HashSet
 
 namespace Std

--- a/YatimaStdLib/HashSet.lean
+++ b/YatimaStdLib/HashSet.lean
@@ -2,7 +2,7 @@ import Lean.Data.HashSet
 
 syntax "⦃" term,* "⦄" : term
 
-open Std
+open Lean
 
 open Lean in
 macro_rules

--- a/YatimaStdLib/RBMap.lean
+++ b/YatimaStdLib/RBMap.lean
@@ -1,4 +1,4 @@
-import Lean
+import Std.Data.RBMap
 
 namespace Std.RBMap
 
@@ -8,28 +8,21 @@ def single (a : α) (b : β) : RBMap α β cmp :=
   RBMap.empty.insert a b
 
 def enumList (xs : List α) : RBMap α Nat cmp :=
-  RBMap.ofList $ xs.enum.map (fun (x, y) => (y, x))
+  RBMap.ofList (xs.enum.map (fun (x, y) => (y, x))) cmp
 
 def unitMap (xs : List α) : RBMap α Unit cmp :=
-  RBMap.ofList $ xs.map (fun x => (x, ()))
+  RBMap.ofList (xs.map (fun x => (x, ()))) cmp
 
-def filterOut [BEq α] [Ord α] (map : RBMap α β cmp) (t : RBTree α cmp) :
+def filterOut [BEq α] [Ord α] (map : RBMap α β cmp) (t : Lean.RBTree α cmp) :
     RBMap α β cmp :=
-  map.fold (init := default) fun acc a b =>
-    if t.contains a then acc else acc.insert a b
-
-def keys : RBMap α β cmp → Array α
-  | ⟨t, _⟩ => t.revFold (fun ks k _ => ks.push k) .empty
-
-def values : RBMap α β cmp → Array β
-  | ⟨t, _⟩ => t.revFold (fun vs _ v => vs.push v) .empty
+  RBMap.foldl (fun acc a b => if t.contains a then acc else acc.insert a b) map (init := default)
 
 /-
   Merge two RBMaps, always taking the first value in case of a key
   being present in both maps. Intended for set simulation.
 -/
 def mergeKeySets (m1 : RBMap α β cmp) m2 :=
-  RBMap.mergeBy (fun _ v _ => v) m1 m2
+  RBMap.mergeWith (fun _ v _ => v) m1 m2
 
 instance : Append (RBMap α Unit cmp) := ⟨RBMap.mergeKeySets⟩
 

--- a/YatimaStdLib/RBMap.lean
+++ b/YatimaStdLib/RBMap.lean
@@ -13,7 +13,7 @@ def enumList (xs : List α) : RBMap α Nat cmp :=
 def unitMap (xs : List α) : RBMap α Unit cmp :=
   RBMap.ofList (xs.map (fun x => (x, ()))) cmp
 
-def filterOut [BEq α] [Ord α] (map : RBMap α β cmp) (t : Lean.RBTree α cmp) :
+def filterOut [BEq α] [Ord α] (map : RBMap α β cmp) (t : RBSet α cmp) :
     RBMap α β cmp :=
   RBMap.foldl (fun acc a b => if t.contains a then acc else acc.insert a b) map (init := default)
 

--- a/YatimaStdLib/RBNode.lean
+++ b/YatimaStdLib/RBNode.lean
@@ -4,8 +4,6 @@ open Std Lean
 
 namespace Lean.RBNode
 
-#check Lean.RBNode
-
 @[specialize] def toList (map : Lean.RBNode α fun _ => β) : List (α × β) :=
   map.revFold (fun as a b => (a, b) :: as) []
 

--- a/YatimaStdLib/RBNode.lean
+++ b/YatimaStdLib/RBNode.lean
@@ -1,15 +1,18 @@
-import Lean
-open Std RBNode
+import Std.Data.RBMap
 
-namespace Std.RBNode
+open Std Lean
 
-@[specialize] def toList (map : RBNode α (fun _ => β)) : List (α × β) :=
+namespace Lean.RBNode
+
+#check Lean.RBNode
+
+@[specialize] def toList (map : Lean.RBNode α fun _ => β) : List (α × β) :=
   map.revFold (fun as a b => (a, b) :: as) []
 
-instance [BEq α] [BEq β] : BEq (RBNode α fun _ => β) where
+instance [BEq α] [BEq β] : BEq (Lean.RBNode α fun _ => β) where
   beq a b := RBNode.toList a == RBNode.toList b
 
-end Std.RBNode
+end Lean.RBNode
 
 namespace Std.RBMap
 

--- a/YatimaStdLib/StringInterner/Interner.lean
+++ b/YatimaStdLib/StringInterner/Interner.lean
@@ -1,5 +1,5 @@
 import YatimaStdLib.StringInterner.Backend.Module
-import Lean.Data.HashMap
+import Std.Data.HashMap
 
 /-!
 # String Interner

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,5 +3,8 @@ open Lake DSL
 
 package YatimaStdLib
 
-@[defaultTarget]
+require std from git
+  "https://github.com/leanprover/std4/"@"f648e43ef696ce1cf7f6ec534ec44c06816380f9"
+
+@[default_target]
 lean_lib YatimaStdLib

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-09-11
+leanprover/lean4:nightly-2022-10-27

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,0 +1,6 @@
+{"version": 2,
+ "packages":
+ [{"url": "https://github.com/leanprover/std4/",
+   "rev": "f648e43ef696ce1cf7f6ec534ec44c06816380f9",
+   "name": "std",
+   "inputRev": "f648e43ef696ce1cf7f6ec534ec44c06816380f9"}]}


### PR DESCRIPTION
Noteworthy changes:

* Added `std4` as a dependency
* Migrated from `Lean.RBMap` to `Std.RBMap`
* Change reference of `Lean.RBTree` to `Std.RBSet`
* Eliminated `RBMap.keys` and `RBMap.values` in favor of the Lean versions (and `.toArray` methods)
* Left `Lean.RBNode` for now
* Left `Lean.HashSet` for now (because `Std.HashSet` isn't implemented yet)