### PR TITLE
Fix OfNat

### DIFF
--- a/YatimaStdLib/AbstractMatrix.lean
+++ b/YatimaStdLib/AbstractMatrix.lean
@@ -11,7 +11,7 @@ def Matrix (A : Type) (r c : Nat) : Type := Fin c → Fin r → A
 
 namespace Matrix
 
-variable [Inhabited A] [Add A] [Mul A] [OfNat A 0]
+variable [Inhabited A] [Add A] [Mul A] [OfNat A (nat_lit 0)]
 
 def last (f : Fin n.succ → A) : Fin n → A := f ∘ Fin.succ
 

--- a/YatimaStdLib/Bit.lean
+++ b/YatimaStdLib/Bit.lean
@@ -15,10 +15,10 @@ instance : ToString Bit where
     | .one  => "1"
     | .zero => "0"
 
-instance : OfNat Bit 0 where
+instance : OfNat Bit (nat_lit 0) where
   ofNat := .zero
 
-instance : OfNat Bit 1 where
+instance : OfNat Bit (nat_lit 1) where
   ofNat := .one
 
 section bit_methods

--- a/YatimaStdLib/Either.lean
+++ b/YatimaStdLib/Either.lean
@@ -135,7 +135,7 @@ def fixs (c : χ) : Either ε (α × τ) → (Either ε α) × χ
   | .left  e      => (.left  e, c)
   | .right (a, _) => (.right a, c)
 
-def fixs' [OfNat M 1] (c : χ) : Either ε (α × τ × M) → (Either ε α) × χ × M
+def fixs' [OfNat M (nat_lit 1)] (c : χ) : Either ε (α × τ × M) → (Either ε α) × χ × M
   | .left  e         => (.left  e, c, 1)
   | .right (a, _, m) => (.right a, c, m)
 

--- a/YatimaStdLib/Matrix.lean
+++ b/YatimaStdLib/Matrix.lean
@@ -16,7 +16,7 @@ abbrev Vector := Array R
 
 namespace Vector
 
-variable {R} [OfNat R 0]
+variable {R} [OfNat R (nat_lit 0)]
 
 /-
 NOTE : All these definitions only make sense when we know that the two arrays representing the
@@ -34,7 +34,7 @@ def dot (v w : Vector R) : R := v.zip w |>.foldr (fun (x, y) acc => acc + x * y)
 
 def scale (r : R) (v : Vector R) : Vector R := v.map fun x => x * r
 
-def zero (R) [OfNat R 0] (dim : Nat) : Vector R := Array.mkArray dim 0
+def zero (R) [OfNat R (nat_lit 0)] (dim : Nat) : Vector R := Array.mkArray dim 0
 
 instance : HMul R (Vector R) (Vector R) := ⟨scale⟩
 

--- a/YatimaStdLib/Polynomial.lean
+++ b/YatimaStdLib/Polynomial.lean
@@ -10,7 +10,7 @@ def tail (ar : Polynomial A) : Polynomial A :=
     | [] => Array.empty
     | (_ :: xs) => Array.mk xs
 
-variable {A : Type} [Add A] [Mul A] [HPow A Nat A] [OfNat A 1] [OfNat A 0] 
+variable {A : Type} [Add A] [Mul A] [HPow A Nat A] [OfNat A (nat_lit 1)] [OfNat A (nat_lit 0)] 
                     [hab : Inhabited A] [eq : BEq A] [Div A] [Neg A]
 
 def dropWhile (p : A → Bool) (f : Polynomial A) : Polynomial A :=
@@ -110,10 +110,10 @@ def rootsToPoly (a : List A) : Polynomial A :=
       let monom : Polynomial A := #[root,-1]
       monom * (rootsToPoly roots)
 
-instance : OfNat (Polynomial A) 1 where
+instance : OfNat (Polynomial A) (nat_lit 1) where
   ofNat := #[1]
 
-instance : OfNat (Polynomial A) 0 where
+instance : OfNat (Polynomial A) (nat_lit 0) where
   ofNat := zero
 
 end Polynomial

--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -1,6 +1,6 @@
-class Ring (R : Type) extends Add R, Mul R, OfNat R (0 : Nat), HPow R Nat R
+class Ring (R : Type) extends Add R, Mul R, OfNat R (nat_lit 0), HPow R Nat R
 
 instance [Add R] [Mul R] [OfNat R 0] [HPow R Nat R] : Ring R := {}
 
-instance [Ring R] [OfNat R 0] : Inhabited R where
+instance [Ring R] : Inhabited R where
   default := 0


### PR DESCRIPTION
There is a seemingly strange quirk of Lean's typeclass resolution system where the following example fails:

```lean
class Foo (K : Type) where
  one : K

instance {K : Type} [Foo K] : OfNat K 1 where
  ofNat := Foo.one

def getOne (K : Type) [OfNat K 1] : K := 1

example {K : Type} [Foo K] : K := getOne K -- failed to synthesize instance
                                           -- OfNat K 1
```

despite having written an instance of `OfNat K 1` which Lean should infer from `Foo K`. This leads to a lot of situations where the `[OfNat K 1]` instance has to be written in manually for each declaration. 

The solution is to replace all references of `OfNat K 1` to `OfNat K (nat_lit 1)`

```lean
class Foo (K : Type) where
  one : K

instance {K : Type} [Foo K] : OfNat K (nat_lit 1) where
  ofNat := Foo.one

def getOne (K : Type) [OfNat K (nat_lit 1)] : K := 1

example {K : Type} [Foo K] : K := 1

example {K : Type} [Foo K] : K := getOne K -- Works!
```

This PR addresses this fix, and aims to clean up the workarounds that are no longer necessary.