### PR TITLE
Move Cronos

### DIFF
--- a/YatimaStdLib/Cronos.lean
+++ b/YatimaStdLib/Cronos.lean
@@ -1,0 +1,28 @@
+import YatimaStdLib.RBMap
+
+structure Cronos where
+  refs : Std.RBMap String Nat compare
+  data : Std.RBMap String Nat compare
+  deriving Inhabited
+
+namespace Cronos
+
+def new : Cronos :=
+  default
+
+variable (c : Cronos)
+
+def clock (tag : String) : IO Cronos := do
+  let now ← IO.monoMsNow
+  match c.refs.find? tag with
+  | none => return { c with refs := c.refs.insert tag now }
+  | some ref => return {
+    refs := c.refs.insert tag now,
+    data := c.data.insert tag (now - ref) }
+
+def summary : String :=
+  let timings := c.data.foldl (init := "")
+    fun acc tag time => s!"{acc}\n  {tag} | {(Float.ofNat time) / 1000}s"
+  s!"Timings:{timings}"
+
+end Cronos

--- a/YatimaStdLib/Cronos.lean
+++ b/YatimaStdLib/Cronos.lean
@@ -13,7 +13,7 @@ def new : Cronos :=
 variable (c : Cronos)
 
 def clock (tag : String) : IO Cronos := do
-  let now ← IO.monoMsNow
+  let now ← IO.monoNanosNow
   match c.refs.find? tag with
   | none => return { c with refs := c.refs.insert tag now }
   | some ref => return {
@@ -22,7 +22,7 @@ def clock (tag : String) : IO Cronos := do
 
 def summary : String :=
   let timings := c.data.foldl (init := "")
-    fun acc tag time => s!"{acc}\n  {tag} | {(Float.ofNat time) / 1000}s"
+    fun acc tag time => s!"{acc}\n  {tag} | {(Float.ofNat time) / 1000000000}s"
   s!"Timings:{timings}"
 
 end Cronos


### PR DESCRIPTION
This PR moves Cronos from the `yatima-lang` to YatimaStdLib to allow for profiling in our other repos.

The only change is the increase of resolution by changing `IO.monoMsNow` to `IO.monoNanosNow`. 