### PR TITLE
Nat To Ring coercion

### DIFF
--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -2,5 +2,13 @@ class Ring (R : Type) extends Add R, Mul R, Sub R, OfNat R (nat_lit 0), OfNat R 
 
 instance [Add R] [Mul R] [Sub R] [OfNat R 0] [OfNat R 1] [HPow R Nat R] : Ring R := {}
 
+def natToRing [Ring R] (n : Nat) : R :=
+  match n with
+    | 0 => 0
+    | k + 1 => natToRing k + 1
+
+instance [Ring R] : Coe Nat R where
+  coe := natToRing
+
 instance [Ring R] : Inhabited R where
   default := 0


### PR DESCRIPTION
Actually, we can embed integers to an arbitrary ring uniquely, here's the version of that fact formulated for natural numbers that would allow reducing the number of constrains in Nova