### PR TITLE
Add `DataClasses.lean` and enhance `LightData`

### DIFF
--- a/Tests/LightData.lean
+++ b/Tests/LightData.lean
@@ -6,7 +6,8 @@ def data : List LightData := [
   (none : Option Nat), some 3, some (some 2), ("ars", 3, some #[3]),
   (.left 1 : Either Nat String), (.right #[3] : Either Nat (Array Nat)),
   .arr #[true, false, 0, 1, 255, 256, 300, 300000, "", "aaa", "\\", "\""],
-  .arr #[.arr #[false, .arr #[true, 1, "hello", "world"]]]
+  .arr #[.arr #[false, .arr #[true, 1, "hello", "world"]]],
+  .big 2 (.ofNat 3), .big 2 (.ofNat 10), .big 10 (.ofNat UInt64.size.succ)
 ]
 
 open LSpec

--- a/Tests/LightData.lean
+++ b/Tests/LightData.lean
@@ -10,8 +10,8 @@ def data : List LightData := [
 open LSpec
 
 #lspec data.foldl (init := .done) fun tSeq d =>
-  let bytes := d.serialize
-  tSeq ++ withExceptOk s!"{d} deserializes" (LightData.deserialize bytes)
+  let bytes := d.toByteArray
+  tSeq ++ withExceptOk s!"{d} deserializes" (LightData.ofByteArray bytes)
     fun d' => test s!"{d} roundtrips" (d == d')
 
 #lspec data.foldl (init := .done) fun tSeq d =>

--- a/Tests/LightData.lean
+++ b/Tests/LightData.lean
@@ -2,9 +2,11 @@ import LSpec
 import YatimaStdLib.LightData
 
 def data : List LightData := [
-  .nil, true, false, 0, 1, 255, 256, 300, 300000, "", "aaa", "\\", "\"",
-  .arr #[.nil, true, false, 0, 1, 255, 256, 300, 300000, "", "aaa", "\\", "\""],
-  .arr #[.nil, .arr #[.nil, .arr #[.nil, 1, "hello", "world"]]]
+  true, false, 0, 1, 255, 256, 300, 300000, "", "aaa", "\\", "\"",
+  (none : Option Nat), some 3, some (some 2), ("ars", 3, some #[3]),
+  (.left 1 : Either Nat String), (.right #[3] : Either Nat (Array Nat)),
+  .arr #[true, false, 0, 1, 255, 256, 300, 300000, "", "aaa", "\\", "\""],
+  .arr #[.arr #[false, .arr #[true, 1, "hello", "world"]]]
 ]
 
 open LSpec

--- a/YatimaStdLib/DataClasses.lean
+++ b/YatimaStdLib/DataClasses.lean
@@ -1,14 +1,14 @@
 /--
-If any `a : α` can be serialized into `d : δ` for a data format `δ` and if
-there's a function that deserializes `d` back to `a`, being allowed to throw
-errors (of any type `ε`), then we say that `α` has a "SerDe" interface to `δ`
+If any `a : α` can be mapped to `d : δ` for a data format `δ` and if there's a
+function that maps `d` back to `a`, being allowed to throw errors (of any type
+`ε`), then we say that we have a data mapping from `α` to `δ`
 -/
-class SerDe (α δ : Type _) (ε : outParam $ Type _) where
+class DataMap (α δ : Type _) (ε : outParam $ Type _) where
   ser : α → δ
   de : δ → Except ε α
 
-/-- Any `SerDe α δ _` instance gives us a trivial `Coe α δ` instance -/
-instance [SerDe α δ ε] : Coe α δ := ⟨SerDe.ser⟩
+/-- Any `DataMap α δ _` instance gives us a trivial `Coe α δ` instance -/
+instance [DataMap α δ ε] : Coe α δ := ⟨DataMap.ser⟩
 
 /--
 If a data format `δ` can be hashed to a type `τ` and if there is a way to

--- a/YatimaStdLib/DataClasses.lean
+++ b/YatimaStdLib/DataClasses.lean
@@ -1,0 +1,23 @@
+/--
+If any `a : α` can be serialized into `d : δ` for a data format `δ` and if
+there's a function that deserializes `d` back to `a`, being allowed to throw
+errors (of any type `ε`), then we say that `α` has a "SerDe" interface to `δ`
+-/
+class SerDe (α δ : Type _) (ε : outParam $ Type _) where
+  ser : α → δ
+  de : δ → Except ε α
+
+/-- Any `SerDe α δ _` instance gives us a trivial `Coe α δ` instance -/
+instance [SerDe α δ ε] : Coe α δ := ⟨SerDe.ser⟩
+
+/--
+If a data format `δ` can be hashed to a type `τ` and if there is a way to
+represent terms of `τ` as terms of `δ`, then we say that `δ` has a hash
+representation of `τ`
+-/
+class HashRepr (δ τ : Type _) where
+  hashFunc : δ → τ
+  hashRepr : τ → δ
+
+/-- A `HashRepr δ UInt64` instance gives us a trivial `Hashable δ` instance -/
+instance [HashRepr δ UInt64] : Hashable δ := ⟨HashRepr.hashFunc⟩

--- a/YatimaStdLib/DataClasses.lean
+++ b/YatimaStdLib/DataClasses.lean
@@ -1,14 +1,14 @@
 /--
-If any `a : α` can be mapped to `d : δ` for a data format `δ` and if there's a
-function that maps `d` back to `a`, being allowed to throw errors (of any type
-`ε`), then we say that we have a data mapping from `α` to `δ`
+`Encodable α δ ε` means that `α` is encodable into a data format `δ` with some 
+injection `encode : α → δ`. It also provides a partial function `decode : δ → α`
+that may throws errors `ε` for elements with no preimage
 -/
-class DataMap (α δ : Type _) (ε : outParam $ Type _) where
-  ser : α → δ
-  de : δ → Except ε α
+class Encodable (α δ : Type _) (ε : outParam $ Type _) where
+  encode : α → δ
+  decode : δ → Except ε α
 
 /-- Any `DataMap α δ _` instance gives us a trivial `Coe α δ` instance -/
-instance [DataMap α δ ε] : Coe α δ := ⟨DataMap.ser⟩
+instance [Encodable α δ ε] : Coe α δ := ⟨Encodable.encode⟩
 
 /--
 If a data format `δ` can be hashed to a type `τ` and if there is a way to

--- a/YatimaStdLib/LightData.lean
+++ b/YatimaStdLib/LightData.lean
@@ -1,5 +1,5 @@
 import YatimaStdLib.ByteArray
-import YatimaStdLib.FFI.UIntByteArray
+import YatimaStdLib.DataClasses
 
 inductive LightData
   | nil : LightData
@@ -16,7 +16,7 @@ inductive LightData
 namespace LightData
 
 partial def toString : LightData → String
-  | .nil => "nil"
+  | .nil       => "nil"
   | .bol true  => "tt"
   | .bol false => "ff"
   | .u8  x => s!"{x}ᵤ₈"
@@ -29,22 +29,53 @@ partial def toString : LightData → String
 
 instance : ToString LightData := ⟨LightData.toString⟩
 
+section DataToOfLightData
+
 partial def ofNat (x : Nat) : LightData :=
-  if x < UInt8.size then .u8 (.ofNat x)
-  else if x < UInt16.size then .u16 (.ofNat x)
-  else if x < UInt32.size then .u32 (.ofNat x)
-  else if x < UInt64.size then .u64 (.ofNat x)
+  if x < UInt8.size then u8 (.ofNat x)
+  else if x < UInt16.size then u16 (.ofNat x)
+  else if x < UInt32.size then u32 (.ofNat x)
+  else if x < UInt64.size then u64 (.ofNat x)
   else ofNat $ x % UInt64.size -- overflow
 
-instance : Coe Bool   LightData := ⟨.bol⟩
-instance : Coe UInt8  LightData := ⟨.u8⟩
-instance : Coe UInt16 LightData := ⟨.u16⟩
-instance : Coe UInt32 LightData := ⟨.u32⟩
-instance : Coe UInt64 LightData := ⟨.u64⟩
-instance : Coe Nat    LightData := ⟨.ofNat⟩
-instance : Coe String LightData := ⟨.str⟩
+instance : SerDe LightData LightData ε where
+  ser := id
+  de  := pure
+
+instance : SerDe Bool LightData String where
+  ser := bol
+  de | bol x => pure x | x => throw s!"Expected a boolean but got {x}"
+
+instance : SerDe Nat LightData String where
+  ser := ofNat
+  de
+    | u8 x | u16 x | u32 x | u64 x => pure x.toNat
+    | x => throw s!"Expected a numeric value but got {x}"
+
+instance : SerDe String LightData String where
+  ser := str
+  de | str x => pure x | x => throw s!"Expected a string but got {x}"
+
+instance [SerDe α LightData String] : SerDe (Array α) LightData String where
+  ser x := arr $ x.map SerDe.ser
+  de | arr x => x.mapM SerDe.de | x => throw s!"Expected an array but got {x}"
+
+instance [SerDe α LightData String] : SerDe (List α) LightData String where
+  ser x := arr $ .mk $ x.map SerDe.ser
+  de | arr x => x.data.mapM SerDe.de | x => throw s!"Expected an array but got {x}"
+
+instance [h : SerDe α LightData String] : SerDe (Option α) LightData String where
+  ser | none => nil | some a => arr #[SerDe.ser a]
+  de
+    | nil => return none
+    | arr #[x] => h.de x
+    | x => throw s!"Expected an array but got {x}"
 
 instance : OfNat LightData n := ⟨.ofNat n⟩
+
+end DataToOfLightData
+
+section LightDataToOfByteArray
 
 def tag : LightData → UInt8
   | nil   => 0
@@ -57,6 +88,92 @@ def tag : LightData → UInt8
   | str _ => 7
   | arr _ => 8
 
+partial def toByteArray : LightData → ByteArray
+  | nil => .mk #[0]
+  | d@(bol false) => .mk #[d.tag, 0]
+  | d@(bol true) => .mk #[d.tag, 1]
+  | d@(u8  x) => .mk #[d.tag, x]
+  | d@(u16 x)
+  | d@(u32 x)
+  | d@(u64 x)
+  | d@(lnk x) => .mk #[d.tag] ++ x.toByteArrayC
+  | d@(str x) => let x := x.toUTF8; .mk #[d.tag] ++ toByteArray x.size ++ x
+  | d@(arr x) =>
+    let init := ⟨#[d.tag]⟩ ++ toByteArray x.size
+    x.foldl (fun acc x => acc.append x.toByteArray) init
+
+structure Bytes where
+  bytes : ByteArray
+  size  : Nat
+  valid : bytes.size = size
+
+abbrev OfBytesM := ReaderT Bytes $ ExceptT String $ StateM Nat
+
+def readUInt8 : OfBytesM UInt8 := do
+  let idx ← get
+  let ctx ← read
+  if h : idx < ctx.size then
+    set idx.succ
+    return ctx.bytes.get ⟨idx, by rw [ctx.valid]; exact h⟩
+  else throw "No more bytes to read"
+
+def readBool : OfBytesM Bool := do
+  match ← readUInt8 with
+  | 0 => return false
+  | 1 => return true
+  | x => throw s!"Invalid data for bool: {x}"
+
+def readByteArray (n : Nat) : OfBytesM ByteArray := do
+  let idx ← get
+  let ctx ← read
+  if idx + n - 1 < ctx.size then
+    set $ idx + n
+    return ctx.bytes.copySlice idx .empty 0 n
+  else throw s!"Not enough data to read {n} bytes (size {ctx.size}, idx {idx})"
+
+def readUInt16 : OfBytesM UInt16 :=
+  return .ofByteArrayC $ ← readByteArray 2
+
+def readUInt32 : OfBytesM UInt32 :=
+  return .ofByteArrayC $ ← readByteArray 4
+
+def readUInt64 : OfBytesM UInt64 :=
+  return .ofByteArrayC $ ← readByteArray 8
+
+def readNat : OfBytesM Nat := do
+  match ← readUInt8 with
+  | 2 => return (←  readUInt8).toNat
+  | 3 => return (← readUInt16).toNat
+  | 4 => return (← readUInt32).toNat
+  | 5 => return (← readUInt64).toNat
+  | x => throw s!"Invalid tag for a numeric value: {x}"
+
+partial def readLightData : OfBytesM LightData := do
+  match ← readUInt8 with
+  | 0 => return nil
+  | 1 => return bol $ ← readBool
+  | 2 => return u8  $ ← readUInt8
+  | 3 => return u16 $ ← readUInt16
+  | 4 => return u32 $ ← readUInt32
+  | 5 => return u64 $ ← readUInt64
+  | 6 => return lnk $ ← readUInt64
+  | 7 => return str $ .fromUTF8Unchecked $ ← readByteArray (← readNat)
+  | 8 =>
+    return arr $ ← List.range (← readNat) |>.foldlM (init := #[]) fun acc _ => do
+      pure $ acc.push (← readLightData)
+  | x => throw s!"Invalid LightData tag: {x}"
+
+def ofByteArray (bytes : ByteArray) : Except String LightData :=
+  (StateT.run (ReaderT.run readLightData ⟨bytes, bytes.size, by eq_refl⟩) 0).1
+
+instance : SerDe LightData ByteArray String where
+  ser := toByteArray
+  de  := ofByteArray
+
+end LightDataToOfByteArray
+
+section Hashing
+
 protected partial def hash : LightData → UInt64
   | nil => 0
   | d@(bol x)
@@ -68,85 +185,10 @@ protected partial def hash : LightData → UInt64
   | d@(str x) => hash (d.tag, x)
   | d@(arr x) => hash (d.tag, x.map (·.hash))
 
-partial def serialize : LightData → ByteArray
-  | nil => .mk #[0]
-  | d@(bol false) => .mk #[d.tag, 0]
-  | d@(bol true) => .mk #[d.tag, 1]
-  | d@(u8  x) => .mk #[d.tag, x]
-  | d@(u16 x)
-  | d@(u32 x)
-  | d@(u64 x)
-  | d@(lnk x) => .mk #[d.tag] ++ x.toByteArrayC
-  | d@(str x) => let x := x.toUTF8; .mk #[d.tag] ++ serialize x.size ++ x
-  | d@(arr x) =>
-    let init := ⟨#[d.tag]⟩ ++ serialize x.size
-    x.foldl (fun acc x => acc.append x.serialize) init
+instance : HashRepr LightData UInt64 where
+  hashFunc := LightData.hash
+  hashRepr := lnk
 
-structure DeContext where
-  bytes : ByteArray
-  size  : Nat
-  valid : bytes.size = size
-
-abbrev DeM := ReaderT DeContext $ ExceptT String $ StateM Nat
-
-def deUInt8 : DeM UInt8 := do
-  let idx ← get
-  let ctx ← read
-  if h : idx < ctx.size then
-    set idx.succ
-    return ctx.bytes.get ⟨idx, by rw [ctx.valid]; exact h⟩
-  else throw "No more bytes to read"
-
-def deBool : DeM Bool := do
-  match ← deUInt8 with
-  | 0 => return false
-  | 1 => return true
-  | x => throw s!"Invalid data for bool: {x}"
-
-def deByteArray (n : Nat) : DeM ByteArray := do
-  let idx ← get
-  let ctx ← read
-  if idx + n - 1 < ctx.size then
-    set $ idx + n
-    return ctx.bytes.copySlice idx .empty 0 n
-  else throw s!"Not enough data to read {n} bytes (size {ctx.size}, idx {idx})"
-
-def deUInt16 : DeM UInt16 :=
-  return .ofByteArrayC $ ← deByteArray 2
-
-def deUInt32 : DeM UInt32 :=
-  return .ofByteArrayC $ ← deByteArray 4
-
-def deUInt64 : DeM UInt64 :=
-  return .ofByteArrayC $ ← deByteArray 8
-
-def deNat : DeM Nat := do
-  match ← deUInt8 with
-  | 2 => return (←  deUInt8).toNat
-  | 3 => return (← deUInt16).toNat
-  | 4 => return (← deUInt32).toNat
-  | 5 => return (← deUInt64).toNat
-  | x => throw s!"Invalid tag for a numeric value: {x}"
-
-def deString : DeM String :=
-  return .fromUTF8Unchecked $ ← deByteArray (← deNat)
-
-partial def deLightData : DeM LightData := do
-  match ← deUInt8 with
-  | 0 => return .nil
-  | 1 => return .bol $ ← deBool
-  | 2 => return .u8  $ ← deUInt8
-  | 3 => return .u16 $ ← deUInt16
-  | 4 => return .u32 $ ← deUInt32
-  | 5 => return .u64 $ ← deUInt64
-  | 6 => return .lnk $ ← deUInt64
-  | 7 => return .str $ ← deString
-  | 8 =>
-    return .arr $ ← List.range (← deNat) |>.foldlM (init := #[]) fun acc _ => do
-      pure $ acc.push (← deLightData)
-  | x => throw s!"Invalid LightData tag: {x}"
-
-def deserialize (bytes : ByteArray) : Except String LightData :=
-  (StateT.run (ReaderT.run deLightData ⟨bytes, bytes.size, by eq_refl⟩) 0).1
+end Hashing
 
 end LightData


### PR DESCRIPTION
This PR adds two typeclasses:
* `HashRepr` to generalize data formats that have hashing functions and that have inner representations for their hashes
* `Encodable` to generalize conversion interfaces between datatypes

These are the basic needs from any data format that we want to use on `yatima-lang`