### PR TITLE
Remove Ring instance

### DIFF
--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -1,7 +1,5 @@
 class Ring (R : Type) extends Add R, Mul R, Sub R, OfNat R (nat_lit 0), OfNat R (nat_lit 1), HPow R Nat R
 
-instance [Add R] [Mul R] [Sub R] [OfNat R 0] [OfNat R 1] [HPow R Nat R] : Ring R := {}
-
 def natToRing [Ring R] (n : Nat) : R :=
   match n with
     | 0 => 0


### PR DESCRIPTION
It's auto generated by Lean already (via `extends`)