### PR TITLE
Better definition of `NEList`

### DIFF
--- a/YatimaStdLib/List.lean
+++ b/YatimaStdLib/List.lean
@@ -1,4 +1,6 @@
+import YatimaStdLib.Applicative
 import YatimaStdLib.Foldable
+import YatimaStdLib.Traversable
 import Std.Data.List.Basic
 
 namespace List
@@ -34,6 +36,13 @@ instance : Foldable List where
   fold := List.fold
   foldr := List.foldr
   foldl := List.foldl
+
+def traverse [Applicative F] (f : A → F B) : List A → F (List B) :=
+  let cons_f x ys := Applicative.liftA₂ (fun x xs => x :: xs) (f x) ys
+  List.foldr cons_f (pure [])
+
+instance : Traversable List where
+  traverse := List.traverse
 
 -- the `B` suffix avoids name conflicts with mathlib
 def eraseDupB [BEq α] : List α → List α

--- a/YatimaStdLib/NonEmpty.lean
+++ b/YatimaStdLib/NonEmpty.lean
@@ -18,12 +18,13 @@ structure NEList (α : Type u) where
   tail : List α
 
 instance [ToString α] : ToString (NEList α) where
-  toString
-    | xs => s!"{xs.head :: xs.tail}"
+  toString xs := "⟦" ++ xs.tail.foldl (fun acc x => s!"{acc}, {x}") s!"{xs.head}" ++ "⟧"
 
 namespace NEList
 
+@[match_pattern]
 def cons (x : α) (xs : List α) : NEList α := ⟨x, xs⟩
+@[match_pattern]
 def uno (x : α) : NEList α := cons x []
 
 infixr:67 " :| " => NEList.cons
@@ -40,6 +41,7 @@ macro_rules
     `(NEList.cons $x $exprs)
 
 /-- Creates a term of `List α` from the elements of a term of `NEList α` -/
+@[inline]
 def toList (xs : NEList α) : List α := xs.head :: xs.tail
 
 /-- Performs a fold-left on a `NEList`
@@ -95,7 +97,7 @@ instance : Foldable NEList where
   foldl := NEList.foldl
 
 def traverse [Applicative φ] (f : α → φ β) (l : NEList α) : φ (NEList β) :=
-  Applicative.liftA₂ .mk (f l.head) (l.tail.traverse f)
+  Applicative.liftA₂ cons (f l.head) (l.tail.traverse f)
 
 open Traversable in
 instance : Traversable NEList where

--- a/YatimaStdLib/Traversable.lean
+++ b/YatimaStdLib/Traversable.lean
@@ -1,10 +1,5 @@
 import YatimaStdLib.Applicative
 import YatimaStdLib.Foldable
-import YatimaStdLib.List
-
-namespace Traversable
-
-universe u
 
 /-
 Functors representing data structures that can be transformed to structures of the same shape by
@@ -16,6 +11,10 @@ https://hackage.haskell.org/package/base-4.16.1.0/docs/Data-Traversable.html#t:T
 class Traversable (T : Type u → Type u) [Functor T] [Foldable T] where
   traverse : [Applicative F] → (A → F B) → T A → F (T B)
 
+namespace Traversable
+
+universe u
+
 def sequenceA [Applicative F] [Functor T] [Foldable T] [Traversable T] : T (F A) → F (T A) :=
   Traversable.traverse id
 
@@ -24,10 +23,5 @@ def mapM [Monad M] [Functor T] [Foldable T] [Traversable T] : (A → M B) → T 
 
 def sequence [Monad M] [Functor T] [Foldable T] [Traversable T] : T (M A) → M (T A) :=
   sequenceA
-
-instance trList : Traversable List where
-  traverse f :=
-    let cons_f x ys := Applicative.liftA₂ (fun x xs => x :: xs) (f x) ys
-    List.foldr cons_f (pure [])
 
 end Traversable


### PR DESCRIPTION
Previously defined `NEList` was inefficient because conversions between `NEList` and `List`, whichever way, were O(n). With this new definition, conversions will be O(1). In fact, an `NEList` will have the same memory layout as a `List`, so if the compiler is smart enough the conversion will be 0 cost. There's also an added benefit of being able to reuse functions on `List` when defining their `NEList` counterpart, leading to more concise code.