### PR TITLE
Add some `Int` bitwise arithmetics

### DIFF
--- a/Tests/Int.lean
+++ b/Tests/Int.lean
@@ -1,0 +1,42 @@
+import LSpec
+import YatimaStdLib.Int
+
+open LSpec Int
+
+def landTests : TestSeq :=
+  group "bitwise AND" $
+    test "pos pos" (land   42    15  = 10) $
+    test "pos neg" (land   42  (-15) = 32) $
+    test "neg pos" (land (-42)   15  = 6)  $
+    test "neg neg" (land (-42) (-15) = -48)
+
+def lorTests : TestSeq :=
+  group "bitwise OR" $
+    test "pos pos" (lor   42    15  = 47)  $
+    test "pos neg" (lor   42  (-15) = -5)  $
+    test "neg pos" (lor (-42)   15  = -33) $
+    test "neg neg" (lor (-42) (-15) = -9)
+
+def lxorTests : TestSeq :=
+  group "bitwise XOR" $
+    test "pos pos" (lxor   42    15  = 37)  $
+    test "pos neg" (lxor   42  (-15) = -37) $
+    test "neg pos" (lxor (-42)   15  = -39) $
+    test "neg neg" (lxor (-42) (-15) = 39)
+
+def shiftlTests : TestSeq :=
+  group "shift left" $
+    test "pos pos" (shiftLeft 16      2  = 64)  $
+    test "pos neg" (shiftLeft 16    (-2) = 4)   $
+    test "neg pos" (shiftLeft (-16)   2  = -64) $
+    test "neg neg" (shiftLeft (-16) (-2) = -4)
+
+def shiftrTests : TestSeq :=
+  group "shift right" $
+    test "pos pos" (shiftRight 16      2  = 4)  $
+    test "pos neg" (shiftRight 16    (-2) = 64) $
+    test "neg pos" (shiftRight (-16)   2  = -4) $
+    test "neg neg" (shiftRight (-16) (-2) = -64)
+
+def main := lspecIO $
+  landTests ++ lorTests ++ lxorTests ++ shiftlTests ++ shiftrTests

--- a/YatimaStdLib/Bit.lean
+++ b/YatimaStdLib/Bit.lean
@@ -26,6 +26,18 @@ section bit_methods
 
 namespace Bit
 
+def not : Bit → Bit
+  | .zero => .one
+  | .one => .zero
+
+def and : Bit → Bit → Bit
+  | .one, .one => .one
+  | _, _       => .zero
+
+def or : Bit → Bit → Bit
+  | .zero, .zero => .zero
+  | _, _         => .one
+
 def xOr : Bit → Bit → Bit
   | one, zero
   | zero, one => one
@@ -45,6 +57,18 @@ end Bit
 end bit_methods
 
 namespace Bit
+
+def onesComplement (xs : List Bit) : List Bit :=
+  xs.map not
+
+def plusOne (xs : List Bit) : List Bit :=
+  let rec go
+    | []          => []
+    | .one  :: bs => .zero :: go bs
+    | .zero :: bs => .one :: bs
+  List.reverse $ go $ xs.reverse
+
+def twosComplement := plusOne ∘ onesComplement
 
 def arrayXOr (bs : Array Bit) : Bit :=
   bs.foldl (fun b b' => b.xOr b') zero
@@ -79,6 +103,12 @@ def Nat.toBits : Nat → List Bit
     Nat.toBits ((n + 2) / 2) ++ (if n % 2 = 0 then [.zero] else [.one])
   decreasing_by exact Nat.div2_lt h₁;
 
+-- Pads negative Ints with 1s to the next multiple of 8 bits.
+def Int.toBits : Int → List Bit
+  | .ofNat n   => Nat.toBits n
+  | .negSucc m => let bits := Nat.toBits $ m+1
+    Bit.twosComplement $ Bit.listPad ((1 + bits.length / 8) * 8) bits
+
 def UInt8.toBits (u : UInt8) : List Bit :=
   Bit.listPad 8 $ Nat.toBits $ UInt8.toNat u
 
@@ -89,7 +119,7 @@ def ByteArray.toBits (ba : ByteArray) : List Bit :=
 def getBits (n : Nat) : Array (Array Bit) := Id.run do
   let mut answer := #[(.mkArray n 0)]
   for x in [1:2^n] do
-    let xBits := x |> (Nat.toDigits 2 ·) 
+    let xBits := x |> (Nat.toDigits 2 ·)
                    |>.map (fun c => c.toNat - 48)
                    |>.map (fun n => if n == 0 then .zero else .one)
                    |>.reverse

--- a/YatimaStdLib/Nat.lean
+++ b/YatimaStdLib/Nat.lean
@@ -59,6 +59,11 @@ def sigBits (x : Nat) : Nat :=
 def log2' (x : Nat) : Nat :=
   sigBits x - 1
 
+-- Shifts `n` to the left by `m+1`, adding 1 on each shift.
+def shiftLeft1 : Nat → Nat → Nat
+  | n, 0   => n
+  | n, m+1 => shiftLeft1 (2*n+1) m
+
 /--
 Given a natural number n, `nextPowerOfTwo'` returns the smallest power of two
 which is less than or equal to `2^n`.
@@ -114,7 +119,7 @@ def powMod (m b e : Nat) : Nat :=
     if h : e = 0 then r
     else
       let e' := e / 2
-      have : e' < e := 
+      have : e' < e :=
       by exact Nat.div2_lt h
       if e % 2 = 0
       then go ((b*b) % m) e' r              -- TODO : Use Montgomery multiplication here to avoid
@@ -147,7 +152,7 @@ def tonelli (n : Nat) (p : Nat) : Option (Nat × Nat) :=
     zMax := z
     if p - 1 == legendre z p then break
   let mut c := powMod p zMax q
-  let mut r := powMod p n $ (q + 1) / 2  -- TODO : Group together these two exponetiations into a 
+  let mut r := powMod p n $ (q + 1) / 2  -- TODO : Group together these two exponetiations into a
   let mut t := powMod p n q              --        bached Exp to avoid re-calculating some powers
   let mut m := s
   while (t - 1) % p != 0 do
@@ -166,10 +171,10 @@ def tonelli (n : Nat) (p : Nat) : Option (Nat × Nat) :=
   return some (r, p - r)
 
 /-- Prints a `Nat` in its hexadecimal form, given the wanted length -/
-def asHex (n : Nat) (length : Nat) : String := 
-  if n < USize.size then 
-    toString n 
-  else 
+def asHex (n : Nat) (length : Nat) : String :=
+  if n < USize.size then
+    toString n
+  else
     let tail := Nat.toDigits 16 n
     let pad := List.replicate (length - tail.length) '0'
     "0x" ++  List.asString (pad ++ tail)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -69,6 +69,7 @@ end ImportAll
 lean_exe Tests.AddChain
 lean_exe Tests.ByteArray
 lean_exe Tests.ByteVector
+lean_exe Tests.Int
 lean_exe Tests.Nat
 lean_exe Tests.Polynomial
 lean_exe Tests.SparseMatrix


### PR DESCRIPTION
Problem: for Wasm.lean, we need some bithwise arithmetics for `Int`s. Lean's stdlib has those for `Nat`s, but surprisingly not for Ints.

Solution: implemented bitwise AND, OR, and XOR for Ints, as well as left and right shifts. Defined relevant instances. Also added twos complement for Bits.
Wrote relevant tests on Ints.