### PR TITLE
Remove Nat to Ring coercions 

### DIFF
--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -1,10 +1,19 @@
-class Ring (R : Type) extends Add R, Mul R, Sub R, OfNat R (nat_lit 0), OfNat R (nat_lit 1), 
-  HPow R Nat R, BEq R
+class Ring (R : Type) extends Add R, Mul R, Sub R, HPow R Nat R, BEq R where
+  zero : R
+  one : R
 
 namespace Ring
 
 instance {R : Type _} [Add R] [Mul R] [Sub R] [OfNat R (nat_lit 0)] [OfNat R (nat_lit 1)] 
   [HPow R Nat R] [BEq R] : Ring R where
+  zero := 0
+  one := 1
+
+instance [Ring R] : OfNat R (nat_lit 0) where
+  ofNat := zero
+
+instance [Ring R] : OfNat R (nat_lit 1) where
+  ofNat := one
 
 instance [Ring R] : Inhabited R where
   default := 0

--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -1,6 +1,10 @@
-class Ring (R : Type) extends Add R, Mul R, Sub R, OfNat R (nat_lit 0), OfNat R (nat_lit 1), HPow R Nat R, BEq R
+class Ring (R : Type) extends Add R, Mul R, Sub R, OfNat R (nat_lit 0), OfNat R (nat_lit 1), 
+  HPow R Nat R, BEq R
 
 namespace Ring
+
+instance {R : Type _} [Add R] [Mul R] [Sub R] [OfNat R (nat_lit 0)] [OfNat R (nat_lit 1)] 
+  [HPow R Nat R] [BEq R] : Ring R where
 
 def fromNat [Ring R] (n : Nat) : R :=
   match n with
@@ -15,10 +19,6 @@ instance [Ring R] : OfNat R n where
 
 instance [Ring R] : Inhabited R where
   default := 0
-
-instance : Ring Nat where
-
-instance : Ring Int where
 
 end Ring
 

--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -6,17 +6,6 @@ namespace Ring
 instance {R : Type _} [Add R] [Mul R] [Sub R] [OfNat R (nat_lit 0)] [OfNat R (nat_lit 1)] 
   [HPow R Nat R] [BEq R] : Ring R where
 
-def fromNat [Ring R] (n : Nat) : R :=
-  match n with
-    | 0 => 0
-    | k + 1 => fromNat k + 1
-
-instance [Ring R] : Coe Nat R where
-  coe := fromNat
-
-instance [Ring R] : OfNat R n where
-  ofNat := Coe.coe n
-
 instance [Ring R] : Inhabited R where
   default := 0
 


### PR DESCRIPTION
I wasn't totally successful in troubleshooting the issues I was running into, but deleting these instances fixed everything.

I think maybe we should just expect to write an `OfNat` instance by hand for any type instantiating `Ring` going forward. 

(besides, the `Ring.fromNat` function was terribly slow if someone had to use it and didn't implement their own `OfNat` instance)