### PR TITLE
Neg instance for Ring

### DIFF
--- a/YatimaStdLib/Ring.lean
+++ b/YatimaStdLib/Ring.lean
@@ -20,6 +20,9 @@ instance [Ring R] : OfNat R (nat_lit 0) where
 instance [Ring R] : OfNat R (nat_lit 1) where
   ofNat := one
 
+instance [Ring R] : Neg R where
+  neg x := 0 - x 
+
 instance [Ring R] : Inhabited R where
   default := 0
 


### PR DESCRIPTION
It's convenient to negate ring elements sometimes, so here's the instance of `Neg`